### PR TITLE
added eglsubAndroid.so

### DIFF
--- a/device-proprietary-files.txt
+++ b/device-proprietary-files.txt
@@ -33,3 +33,4 @@ vendor/lib/libqmi_cci.so
 vendor/lib/libqmi_common_so.so
 vendor/lib/libqmi_csi.so
 vendor/lib/libqmi_encdec.so
+vendor/lib/egl/eglsubAndroid.so


### PR DESCRIPTION
I added this file to extract, afterwards I could cleanly build 14.1 for my Galaxy S4.
It's running perfectly now for 3 days. Even better than the last 13.0 builds of CM.